### PR TITLE
Added Luhn Algorithm Validation for card number

### DIFF
--- a/fields.py
+++ b/fields.py
@@ -19,7 +19,7 @@ class CreditCardField(forms.CharField):
     default_error_messages = {
         'required': _(u'Please enter a credit card number.'),
         'invalid': _(u'The credit card number you entered is invalid.'),
-        'invalid_luhn': _(u'The credit card number you entered doesn't have a valid checksum'),
+        'invalid_luhn': _(u'The credit card number you entered doesn\'t have a valid checksum.'),
     }
 
     def clean(self, value):


### PR DESCRIPTION
Hey, I have 2 years experience in python/Django. I would like to contribute to a few open source projects. I have added a  feature to validate the credit card number using luhn algorithm and ensure it has the proper check sum. 

For Example:
5544102470137580 this card number will clear the regex validation but will fail the luhn's check sum validation.

Thanks
